### PR TITLE
Timx/zhy 13 实现user模块的api路由

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,7 +12,7 @@ const config: Config = {
     enabled: true,
   },
   [ConfigKey.Security]: {
-    expiresIn: '2m',
+    expiresIn: '120m',
     refreshIn: '1d',
     refreshInForRemembering: '360d',
     bcryptSaltOrRound: 10,

--- a/src/controllers/users/users.controller.ts
+++ b/src/controllers/users/users.controller.ts
@@ -146,7 +146,7 @@ export class UsersController {
     return await this.userService.update(data, user!.id)
   }
 
-  @Put('me/password')
+  @Put('my/password')
   @Roles(Role.USER)
   @ApiBody({ type: UpdatePasswordDto })
   @ApiOperation({ summary: 'Updates own password' })

--- a/src/controllers/users/users.controller.ts
+++ b/src/controllers/users/users.controller.ts
@@ -9,6 +9,7 @@ import {
   Put,
   Query,
   Req,
+  UseGuards,
 } from '@nestjs/common'
 import {
   ApiBadRequestResponse,
@@ -38,8 +39,10 @@ import { User } from '~/models/user.model'
 import { Serializer } from '~/core/decorators/serializer.decorator'
 import { UserService } from '~/services/users/user.service'
 import { Request } from '~/types/http'
+import { AuthGuard } from '~/guards/auth.guard'
 
 @ApiTags('user')
+@UseGuards(AuthGuard)
 @Controller('users')
 export class UsersController {
   @Inject()

--- a/src/controllers/users/users.controller.ts
+++ b/src/controllers/users/users.controller.ts
@@ -1,6 +1,160 @@
-import { Controller } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  Param,
+  Post,
+  Put,
+  Query,
+  Req,
+} from '@nestjs/common'
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger'
+import {
+  CreateUserDto,
+  ForceUpdatePasswordDto,
+  SearchUserDto,
+  UpdatePasswordDto,
+  UpdatePasswordSuccessfulResponse,
+  UpdateRoleDto,
+  UpdateUserDto,
+} from '~/types/user/user'
+import { Role } from '@prisma/client'
+import { Roles } from '~/core/decorators/roles.decorator'
+import { AdminUserService } from '~/services/users/admin.service'
+import { User } from '~/models/user.model'
+import { Serializer } from '~/core/decorators/serializer.decorator'
+import { UserService } from '~/services/users/user.service'
+import { Request } from '~/types/http'
 
+@ApiTags('user')
 @Controller('users')
 export class UsersController {
-  //
+  @Inject()
+  private readonly service!: AdminUserService
+
+  @Inject()
+  private readonly userService!: UserService
+
+  @Post()
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: 'Creates a user' })
+  @ApiBody({ type: CreateUserDto })
+  @ApiConflictResponse({ description: 'Email ${input} already exists.' })
+  @ApiCreatedResponse({ type: User })
+  @Serializer(User)
+  async create(@Body() data: CreateUserDto) {
+    return await this.service.create(data)
+  }
+
+  @Put(':id')
+  @Roles(Role.ADMIN)
+  @ApiBody({ type: UpdateUserDto })
+  @ApiNotFoundResponse({ description: 'The User to update is not found.' })
+  @ApiOperation({ summary: 'Updates a user' })
+  @ApiOkResponse({ type: User })
+  @Serializer(User)
+  async update(@Body() data: UpdateUserDto, @Param('id') id: string) {
+    return await this.service.update(data, id)
+  }
+
+  @Put('password/:id')
+  @Roles(Role.ADMIN)
+  @ApiBody({ type: ForceUpdatePasswordDto })
+  @ApiNotFoundResponse({ description: 'The User to update is not found.' })
+  @ApiOperation({ summary: 'Updates a user password' })
+  @ApiOkResponse({ type: UpdatePasswordSuccessfulResponse })
+  async updatePassword(
+    @Body() data: ForceUpdatePasswordDto,
+    @Param('id') id: string
+  ) {
+    return {
+      data: await this.service.updatePassword(data, id),
+    }
+  }
+
+  @Put('role/:id')
+  @Roles(Role.ADMIN)
+  @ApiBody({ type: UpdateRoleDto })
+  @ApiNotFoundResponse({ description: 'The User to update is not found.' })
+  @ApiOperation({ summary: 'Updates a user role' })
+  @ApiOkResponse({ type: User })
+  @Serializer(User)
+  async updateRole(@Body() data: UpdateRoleDto, @Param('id') id: string) {
+    return await this.service.updateRole(data, id)
+  }
+
+  @Delete(':id')
+  @Roles(Role.ADMIN)
+  @ApiNotFoundResponse({ description: 'The User to delete does not exists.' })
+  @ApiOkResponse({ type: User, description: 'return already deleted user' })
+  @ApiOperation({ summary: 'Deletes a user' })
+  @Serializer(User)
+  async remove(@Param('id') id: string) {
+    return await this.service.remove(id)
+  }
+
+  @Get('search')
+  @Roles(Role.ADMIN)
+  @ApiOkResponse({ type: User, isArray: true })
+  @ApiQuery({ type: SearchUserDto })
+  @ApiOperation({ summary: 'Search users by email/firstname/lastname' })
+  @Serializer(User)
+  async search(@Query() data: SearchUserDto) {
+    return await this.service.search(data)
+  }
+
+  @Get(':id')
+  @Roles(Role.ADMIN)
+  @ApiOkResponse({ type: User })
+  @Serializer(User)
+  async getUser(@Param('id') id: string) {
+    return await this.service.getUser(id)
+  }
+
+  @Get()
+  @Roles(Role.ADMIN)
+  @ApiOkResponse({ type: User, isArray: true })
+  @Serializer(User)
+  async getAllUser() {
+    return await this.service.getAllUser()
+  }
+
+  @Put('update/me')
+  @Roles(Role.USER)
+  @ApiBody({ type: UpdateUserDto })
+  @ApiForbiddenResponse({ description: "You don't have the permission." })
+  @ApiOperation({ summary: 'Updates own user info' })
+  @ApiOkResponse({ type: User })
+  @Serializer(User)
+  async updateMe(@Body() data: UpdateUserDto, @Req() { user }: Request) {
+    return await this.userService.update(data, user!.id)
+  }
+
+  @Put('me/password')
+  @Roles(Role.USER)
+  @ApiBody({ type: UpdatePasswordDto })
+  @ApiOperation({ summary: 'Updates own password' })
+  @ApiOkResponse({ type: UpdatePasswordSuccessfulResponse })
+  @ApiBadRequestResponse({ description: 'password is incorrect' })
+  async updateMyPassword(
+    @Body() data: UpdatePasswordDto,
+    @Req() { user }: Request
+  ) {
+    return {
+      data: await this.userService.updatePassword(data, user!.id),
+    }
+  }
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,2 @@
+export const ROLE_METADATA = 'roles'
+export const SERIALIZER_METADATA = 'serializer'

--- a/src/core/decorators/roles.decorator.ts
+++ b/src/core/decorators/roles.decorator.ts
@@ -1,0 +1,15 @@
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common'
+import { ROLE_METADATA } from '~/core/constants'
+import { Role } from '@prisma/client'
+import { AuthGuard } from '~/guards/auth.guard'
+import { RolesGuard } from '~/guards/roles.guard'
+import { ApiBearerAuth, ApiForbiddenResponse } from '@nestjs/swagger'
+
+export const Roles = (...roles: Role[]): MethodDecorator & ClassDecorator => {
+  return applyDecorators(
+    SetMetadata(ROLE_METADATA, roles),
+    UseGuards(AuthGuard, RolesGuard),
+    ApiBearerAuth(),
+    ApiForbiddenResponse({ description: "You don't have the permission" })
+  )
+}

--- a/src/core/decorators/serializer.decorator.ts
+++ b/src/core/decorators/serializer.decorator.ts
@@ -1,0 +1,17 @@
+import {
+  applyDecorators,
+  ClassSerializerInterceptor,
+  SetMetadata,
+  UseInterceptors,
+} from '@nestjs/common'
+import { SERIALIZER_METADATA } from '~/core/constants'
+import { ClassConstructor } from 'class-transformer'
+import { Model } from '~/core/model/base.model'
+import { SerializerInterceptor } from '~/core/interceptors/serializer.interceptor'
+
+export const Serializer = (cls: ClassConstructor<Model<any>>) => {
+  return applyDecorators(
+    SetMetadata(SERIALIZER_METADATA, cls),
+    UseInterceptors(ClassSerializerInterceptor, SerializerInterceptor)
+  )
+}

--- a/src/core/interceptors/serializer.interceptor.ts
+++ b/src/core/interceptors/serializer.interceptor.ts
@@ -1,0 +1,60 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+  Type,
+} from '@nestjs/common'
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { ModuleRef, Reflector } from '@nestjs/core'
+import { SERIALIZER_METADATA } from '~/core/constants'
+import { Model } from '~/core/model/base.model'
+import { ClassConstructor } from 'class-transformer'
+
+@Injectable()
+export class SerializerInterceptor implements NestInterceptor {
+  app: any
+
+  constructor(private reflector: Reflector, private moduleRef: ModuleRef) {
+    this.app = {}
+  }
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>
+  ): Observable<any> | Promise<Observable<any>> {
+    const model = this.getContextOptions(context)
+
+    return next.handle().pipe(
+      map((data) => {
+        if (data instanceof Array) {
+          return data.map((item) => {
+            return new model(item)
+          })
+        }
+
+        return new model(data)
+      })
+    )
+  }
+
+  private getModelInstance(context: ExecutionContext): Model<any> {
+    const options = this.getContextOptions(context)
+
+    return new options()
+  }
+
+  private getContextOptions(
+    context: ExecutionContext
+  ): ClassConstructor<Model<any>> {
+    return (
+      this.reflectSerializerMetaData(context.getHandler()) ||
+      this.reflectSerializerMetaData(context.getClass())
+    )
+  }
+
+  private reflectSerializerMetaData(obj: Type | Function) {
+    return this.reflector.get(SERIALIZER_METADATA, obj)
+  }
+}

--- a/src/core/interceptors/serializer.interceptor.ts
+++ b/src/core/interceptors/serializer.interceptor.ts
@@ -7,18 +7,14 @@ import {
 } from '@nestjs/common'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { ModuleRef, Reflector } from '@nestjs/core'
+import { Reflector } from '@nestjs/core'
 import { SERIALIZER_METADATA } from '~/core/constants'
 import { Model } from '~/core/model/base.model'
 import { ClassConstructor } from 'class-transformer'
 
 @Injectable()
 export class SerializerInterceptor implements NestInterceptor {
-  app: any
-
-  constructor(private reflector: Reflector, private moduleRef: ModuleRef) {
-    this.app = {}
-  }
+  constructor(private reflector: Reflector) {}
 
   intercept(
     context: ExecutionContext,
@@ -37,12 +33,6 @@ export class SerializerInterceptor implements NestInterceptor {
         return new model(data)
       })
     )
-  }
-
-  private getModelInstance(context: ExecutionContext): Model<any> {
-    const options = this.getContextOptions(context)
-
-    return new options()
   }
 
   private getContextOptions(

--- a/src/core/model/base.model.ts
+++ b/src/core/model/base.model.ts
@@ -4,14 +4,18 @@ import { isNil } from 'lodash'
 export abstract class Model<T extends Object> {
   constructor(data?: T) {
     if (!isNil(data)) {
-      for (const key of Object.keys(data)) {
-        // @ts-ignore
-        this[key] = data[key]
-      }
+      this.init(data)
     }
   }
 
   toJson(options?: ClassTransformOptions) {
     return classToPlain(this, options)
+  }
+
+  protected init(data: T) {
+    for (const key of Object.keys(data)) {
+      // @ts-ignore
+      this[key] = data[key]
+    }
   }
 }

--- a/src/enums/PrismaErrorCode.ts
+++ b/src/enums/PrismaErrorCode.ts
@@ -1,0 +1,4 @@
+export const enum PrismaErrorCode {
+  Unique = 'P2002',
+  NotFound = 'P2025',
+}

--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -1,0 +1,42 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { ROLE_METADATA } from '~/core/constants'
+import { Request } from '~/types/http'
+import { Role } from '@prisma/client'
+import { User } from '~/models/user.model'
+import { isNil } from 'lodash'
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const roles = this.reflector.getAllAndMerge<Role[]>(ROLE_METADATA, [
+      context.getHandler(),
+      context.getClass(),
+    ])
+
+    if (!roles) return true
+
+    const { user } = context.switchToHttp().getRequest<Request>()
+
+    if (
+      !isNil(user) &&
+      !roles.some((role) => user?.role.includes(role)) &&
+      !this.isAdmin(user!)
+    ) {
+      throw new ForbiddenException("You don't have the permission")
+    }
+
+    return true
+  }
+
+  private isAdmin(user: User) {
+    return user.role === Role.ADMIN
+  }
+}

--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -25,12 +25,10 @@ export class RolesGuard implements CanActivate {
 
     const { user } = context.switchToHttp().getRequest<Request>()
 
-    if (
-      !isNil(user) &&
-      !roles.some((role) => user?.role.includes(role)) &&
-      !this.isAdmin(user!)
-    ) {
-      throw new ForbiddenException("You don't have the permission")
+    this.checkUserExists(user)
+
+    if (!this.isAdmin(user!)) {
+      this.checkHaveRole(roles as [], user!)
     }
 
     return true
@@ -38,5 +36,25 @@ export class RolesGuard implements CanActivate {
 
   private isAdmin(user: User) {
     return user.role === Role.ADMIN
+  }
+
+  private checkUserExists(user?: User): boolean {
+    if (isNil(user)) {
+      this.throwForbidden()
+    }
+
+    return true
+  }
+
+  private checkHaveRole(roles: [], user: User): boolean {
+    if (!roles.some((role) => user!.role.includes(role))) {
+      this.throwForbidden()
+    }
+
+    return true
+  }
+
+  private throwForbidden() {
+    throw new ForbiddenException("You don't have the permission")
   }
 }

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,6 +1,6 @@
 import { Role, User as UserObject } from '@prisma/client'
 import { ApiProperty } from '@nestjs/swagger'
-import { Exclude } from 'class-transformer'
+import { Exclude, Expose, Transform } from 'class-transformer'
 import { Model } from '~/core/model/base.model'
 
 export class User extends Model<UserObject> implements UserObject {
@@ -14,9 +14,11 @@ export class User extends Model<UserObject> implements UserObject {
   password!: string
 
   @ApiProperty()
+  @Transform(({ value }) => value.toString())
   createdAt!: Date
 
   @ApiProperty()
+  @Transform(({ value }) => value.toString())
   updatedAt!: Date
 
   @ApiProperty()
@@ -27,4 +29,10 @@ export class User extends Model<UserObject> implements UserObject {
 
   @ApiProperty()
   role!: Role
+
+  @ApiProperty()
+  @Expose({ name: 'name' })
+  get name() {
+    return this.firstname + ' ' + this.lastname
+  }
 }

--- a/src/modules/user.module.ts
+++ b/src/modules/user.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
-import { UserService } from '~/services/users/user.service'
+import { AdminUserService } from '~/services/users/admin.service'
 import { UsersController } from '~/controllers/users/users.controller'
+import { UserService } from '~/services/users/user.service'
 
 @Module({
-  providers: [UserService],
+  providers: [AdminUserService, UserService],
   controllers: [UsersController],
-  exports: [UserService],
+  exports: [AdminUserService, UserService],
 })
 export class UserModule {}

--- a/src/services/users/admin.service.ts
+++ b/src/services/users/admin.service.ts
@@ -29,7 +29,7 @@ export class AdminUserService {
   private readonly hash!: HashService
 
   /**
-   * Create a user.
+   * Creates a user.
    *
    * @param password
    * @param email
@@ -40,12 +40,12 @@ export class AdminUserService {
     email,
     ...data
   }: CreateUserDto): Promise<User> {
-    const hashPassword = await this.hash.make(password)
+    const hashedPassword = await this.hash.make(password)
 
     try {
       return await this.db.user.create({
         data: {
-          password: hashPassword,
+          password: hashedPassword,
           email,
           ...data,
         },
@@ -171,7 +171,7 @@ export class AdminUserService {
   }
 
   /**
-   * Gets all users orderBy desc createdAt
+   * Gets all users (latest first)
    */
   async getAllUser(): Promise<User[]> {
     return await this.db.user.findMany({

--- a/src/services/users/admin.service.ts
+++ b/src/services/users/admin.service.ts
@@ -1,0 +1,208 @@
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
+import { DatabaseService } from '~/services/database.service'
+import { HashService } from '~/services/security/hash.service'
+import {
+  CreateUserDto,
+  ForceUpdatePasswordDto,
+  ForceUpdateUserDto,
+  SearchUserDto,
+  UpdateEmailDto,
+  UpdateRoleDto,
+  UpdateUserDto,
+} from '~/types/user/user'
+import { Prisma, User } from '@prisma/client'
+import { PrismaErrorCode } from '~/enums/PrismaErrorCode'
+
+const defaultPassword = 'zolran666'
+
+@Injectable()
+export class AdminUserService {
+  @Inject()
+  private readonly db!: DatabaseService
+
+  @Inject()
+  private readonly hash!: HashService
+
+  /**
+   * Create a user.
+   *
+   * @param password
+   * @param email
+   * @param data
+   */
+  async create({
+    password = defaultPassword,
+    email,
+    ...data
+  }: CreateUserDto): Promise<User> {
+    const hashPassword = await this.hash.make(password)
+
+    try {
+      return await this.db.user.create({
+        data: {
+          password: hashPassword,
+          email,
+          ...data,
+        },
+      })
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === PrismaErrorCode.Unique
+      ) {
+        throw new ConflictException(`Email ${email} already exists.`)
+      } else {
+        throw new Error(e)
+      }
+    }
+  }
+
+  /**
+   * Force updates a user by id.
+   *
+   * @param data
+   * @param id
+   */
+  async forceUpdate(data: ForceUpdateUserDto, id: string): Promise<User> {
+    try {
+      return await this.db.user.update({
+        where: {
+          id,
+        },
+        data,
+      })
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === PrismaErrorCode.NotFound
+      ) {
+        throw new NotFoundException('The User to update is not found.')
+      }
+
+      throw new Error(e)
+    }
+  }
+
+  /**
+   * Updates a user by id.
+   *
+   * @param data
+   * @param id
+   */
+  async update(data: UpdateUserDto, id: string): Promise<User> {
+    return await this.forceUpdate(data, id)
+  }
+
+  /**
+   * Updates ths password of user.
+   *
+   * @param data
+   * @param id
+   */
+  async updatePassword(
+    data: ForceUpdatePasswordDto,
+    id: string
+  ): Promise<boolean> {
+    data.password = await this.hash.make(data.password)
+
+    await this.forceUpdate(data, id)
+
+    return true
+  }
+
+  /**
+   * Updates the email of user.
+   *
+   * @param data
+   * @param id
+   */
+  async updateEmail(data: UpdateEmailDto, id: string): Promise<User> {
+    return await this.forceUpdate(data, id)
+  }
+
+  /**
+   * Updates the role of user.
+   *
+   * @param data
+   * @param id
+   */
+  async updateRole(data: UpdateRoleDto, id: string): Promise<User> {
+    return await this.forceUpdate(data, id)
+  }
+
+  /**
+   * Deletes a user by id.
+   *
+   * @param id
+   */
+  async remove(id: string): Promise<User> {
+    try {
+      return await this.db.user.delete({ where: { id } })
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === PrismaErrorCode.NotFound
+      ) {
+        throw new NotFoundException('The User to delete does not exist.')
+      }
+
+      throw new Error(e)
+    }
+  }
+
+  /**
+   * Gets a user by id.
+   *
+   * @param id
+   */
+  async getUser(id: string): Promise<User> {
+    const user = await this.db.user.findUnique({ where: { id } })
+
+    if (!user) {
+      throw new NotFoundException(`The User Cannot be found for id: ${id}`)
+    }
+
+    return user
+  }
+
+  /**
+   * Gets all users orderBy desc createdAt
+   */
+  async getAllUser(): Promise<User[]> {
+    return await this.db.user.findMany({
+      orderBy: {
+        createdAt: 'desc',
+      },
+    })
+  }
+
+  /**
+   * Search all users by email/firstname/lastname
+   *
+   * @param data
+   */
+  async search(data: SearchUserDto): Promise<User[]> {
+    return await this.db.user.findMany({
+      where: Object.assign({}, ...this.searchWhere(data)),
+    })
+  }
+
+  /**
+   * Splice Search where
+   *
+   * @param data
+   * @private
+   */
+  private searchWhere(data: SearchUserDto): object[] {
+    return Object.entries(data).map((item) => {
+      return Object.fromEntries([
+        [item[0], Object.fromEntries([['contains', item[1]]])],
+      ])
+    })
+  }
+}

--- a/src/services/users/user.service.ts
+++ b/src/services/users/user.service.ts
@@ -1,20 +1,12 @@
 import {
   BadRequestException,
-  ConflictException,
   Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
 import { DatabaseService } from '~/services/database.service'
 import { HashService } from '~/services/security/hash.service'
-import {
-  CreateUserDto,
-  UpdatePasswordDto,
-  UpdateUserDto,
-} from '~/types/user/user'
-import { PrismaErrorCode } from '~/enums/PrismaErrorCode'
-import { User } from '~/models/user.model'
+import { UpdatePasswordDto, UpdateUserDto } from '~/types/user/user'
 
 @Injectable()
 export class UserService {

--- a/src/services/users/user.service.ts
+++ b/src/services/users/user.service.ts
@@ -1,6 +1,20 @@
-import { Inject, Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
+import { Prisma } from '@prisma/client'
 import { DatabaseService } from '~/services/database.service'
 import { HashService } from '~/services/security/hash.service'
+import {
+  CreateUserDto,
+  UpdatePasswordDto,
+  UpdateUserDto,
+} from '~/types/user/user'
+import { PrismaErrorCode } from '~/enums/PrismaErrorCode'
+import { User } from '~/models/user.model'
 
 @Injectable()
 export class UserService {
@@ -9,4 +23,46 @@ export class UserService {
 
   @Inject()
   private readonly hash!: HashService
+
+  /**
+   * Updates own firstname or lastname.
+   *
+   * @param data
+   * @param id
+   */
+  async update(data: UpdateUserDto, id: string) {
+    return await this.db.user.update({ where: { id }, data })
+  }
+
+  /**
+   * Updates own password
+   * need to validate password
+   *
+   * @param data
+   * @param id
+   */
+  async updatePassword(data: UpdatePasswordDto, id: string) {
+    const user = await this.getUser(id)
+
+    if (!(await this.hash.validate(data.oldPassword, user.password))) {
+      throw new BadRequestException('password is incorrect')
+    }
+
+    return await this.db.user.update({
+      where: { id },
+      data: {
+        password: await this.hash.make(data.password),
+      },
+    })
+  }
+
+  async getUser(id: string) {
+    const user = await this.db.user.findUnique({ where: { id } })
+
+    if (!user) {
+      throw new NotFoundException(`No user found for id: ${id}`)
+    }
+
+    return user
+  }
 }

--- a/src/services/users/user.service.ts
+++ b/src/services/users/user.service.ts
@@ -36,7 +36,7 @@ export class UserService {
   async updatePassword(data: UpdatePasswordDto, id: string) {
     const user = await this.getUser(id)
 
-    if (!(await this.hash.validate(data.oldPassword, user.password))) {
+    if (!(await this.hash.validate(data.currentPassword, user.password))) {
       throw new BadRequestException('password is incorrect')
     }
 
@@ -48,6 +48,11 @@ export class UserService {
     })
   }
 
+  /**
+   * Gets a user
+   *
+   * @param id
+   */
   async getUser(id: string) {
     const user = await this.db.user.findUnique({ where: { id } })
 

--- a/src/types/serializer.ts
+++ b/src/types/serializer.ts
@@ -1,0 +1,5 @@
+export interface CanSerialize<T = any, Model = any> {
+  morph(data: T): Model
+}
+
+export type SerializerResolve = CanSerialize | Function

--- a/src/types/user/user.ts
+++ b/src/types/user/user.ts
@@ -1,0 +1,131 @@
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator'
+import { Role } from '@prisma/client'
+
+export class CreateUserDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  email!: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  password?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  firstname?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  lastname?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsEnum(Role)
+  role?: Role
+}
+
+export class UpdateUserDto {
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  firstname?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  lastname?: string
+}
+
+export class ForceUpdatePasswordDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  password!: string
+}
+
+export class UpdatePasswordDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  password!: string
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  oldPassword!: string
+}
+
+export class UpdateEmailDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  email!: string
+}
+
+export class UpdateRoleDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsEnum(Role)
+  role!: Role
+}
+
+export class ForceUpdateUserDto {
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  email?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  password?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  firstname?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  lastname?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsEnum(Role)
+  role?: Role
+}
+
+export class SearchUserDto {
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  email?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  firstname?: string
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  lastname?: string
+}
+
+export class UpdatePasswordSuccessfulResponse {
+  @ApiProperty()
+  @IsBoolean()
+  data!: boolean
+}

--- a/src/types/user/user.ts
+++ b/src/types/user/user.ts
@@ -1,17 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger'
 import {
   IsBoolean,
+  IsEmail,
   IsEnum,
   IsNotEmpty,
   IsOptional,
   IsString,
+  MinLength,
 } from 'class-validator'
 import { Role } from '@prisma/client'
 
 export class CreateUserDto {
   @ApiProperty()
   @IsNotEmpty()
-  @IsString()
+  @IsEmail()
   email!: string
 
   @ApiProperty()
@@ -51,25 +53,22 @@ export class ForceUpdatePasswordDto {
   @ApiProperty()
   @IsNotEmpty()
   @IsString()
+  @MinLength(6)
   password!: string
 }
 
-export class UpdatePasswordDto {
+export class UpdatePasswordDto extends ForceUpdatePasswordDto {
   @ApiProperty()
   @IsNotEmpty()
   @IsString()
-  password!: string
-
-  @ApiProperty()
-  @IsNotEmpty()
-  @IsString()
-  oldPassword!: string
+  @MinLength(6)
+  currentPassword!: string
 }
 
 export class UpdateEmailDto {
   @ApiProperty()
   @IsNotEmpty()
-  @IsString()
+  @IsEmail()
   email!: string
 }
 
@@ -83,12 +82,13 @@ export class UpdateRoleDto {
 export class ForceUpdateUserDto {
   @ApiProperty()
   @IsOptional()
-  @IsString()
+  @IsEmail()
   email?: string
 
   @ApiProperty()
   @IsOptional()
   @IsString()
+  @MinLength(6)
   password?: string
 
   @ApiProperty()
@@ -110,7 +110,7 @@ export class ForceUpdateUserDto {
 export class SearchUserDto {
   @ApiProperty()
   @IsOptional()
-  @IsString()
+  @IsEmail()
   email?: string
 
   @ApiProperty()

--- a/test/posts/post.e2e-spec.ts
+++ b/test/posts/post.e2e-spec.ts
@@ -14,7 +14,7 @@ const getFakerPost = () => {
   return { title, content, published }
 }
 
-describe('PostController (e2e)', () => {
+describe('PostsController (e2e)', () => {
   let app: INestApplication
   let db: DatabaseService
 

--- a/test/users/users.e2e-spec.ts
+++ b/test/users/users.e2e-spec.ts
@@ -4,7 +4,6 @@ import {
   createAdminUser,
   createUser,
   http,
-  resetDatabase,
   resetsDatabaseAfterAll,
   setupNestApp,
 } from 'test/helpers'
@@ -346,7 +345,6 @@ describe('UsersController (e2e)', () => {
     })
 
     it('should return 404 if administrator want to delete is not found', async () => {
-      // await resetDatabase()
       const { tokens } = await createAdminUser(app)
       const id = faker.datatype.uuid()
 
@@ -398,7 +396,6 @@ describe('UsersController (e2e)', () => {
     const uri = '/users'
 
     it('should return 200 with users array', async () => {
-      // await resetDatabase()
       await db.user.deleteMany()
       const { user, tokens } = await createAdminUser(app)
       const users = []
@@ -595,7 +592,7 @@ describe('UsersController (e2e)', () => {
   })
 
   describe('@PUT /users/me/password', () => {
-    const uri = '/users/me/password'
+    const uri = '/users/my/password'
 
     it('should return 200 with true', async () => {
       const { user, tokens, password } = await createUser(app)

--- a/test/users/users.e2e-spec.ts
+++ b/test/users/users.e2e-spec.ts
@@ -1,0 +1,652 @@
+import { HttpStatus, INestApplication } from '@nestjs/common'
+import { DatabaseService } from '~/services/database.service'
+import {
+  createAdminUser,
+  createUser,
+  http,
+  resetDatabase,
+  resetsDatabaseAfterAll,
+  resetsDatabaseAfterEach,
+  setupNestApp,
+} from 'test/helpers'
+import * as faker from 'faker'
+import { Role, User } from '@prisma/client'
+import { HashService } from '~/services/security/hash.service'
+import modelFactory from '~/core/model/model.factory'
+import { User as UserModel } from '~/models/user.model'
+import { map, shuffle } from 'lodash'
+
+const getFakerUser = () => {
+  const email = faker.internet.email()
+  const password = faker.internet.password()
+  const firstname = faker.name.firstName()
+  const lastname = faker.name.lastName()
+
+  return { email, password, firstname, lastname }
+}
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication
+  let db: DatabaseService
+  let hash: HashService
+
+  beforeAll(async () => {
+    app = await setupNestApp()
+    db = app.get(DatabaseService)
+    hash = app.get(HashService)
+  })
+
+  resetsDatabaseAfterAll(() => app)
+
+  // resetsDatabaseAfterEach()
+
+  describe('@POST /users', () => {
+    const uri = '/users'
+
+    it('should return 201 correctly', async () => {
+      const { tokens } = await createAdminUser(app)
+      const { password, ...rest } = getFakerUser()
+
+      return http(app)
+        .post(uri)
+        .send({
+          password,
+          ...rest,
+        })
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.CREATED)
+        .then(({ body }) => {
+          expect(body).toMatchObject(rest)
+        })
+    })
+
+    it("should return 403 if operator doesn't have the permission.", async () => {
+      const { tokens } = await createUser(app)
+      const user = getFakerUser()
+
+      return http(app)
+        .post(uri)
+        .send(user)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+
+    it('should return 409 if the user email is already exists.', async () => {
+      const { tokens } = await createAdminUser(app)
+      const user = getFakerUser()
+
+      await db.user.create({ data: user })
+
+      return http(app)
+        .post(uri)
+        .send(user)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.CONFLICT)
+        .then(({ body }) => {
+          expect(body.message).toBe(`Email ${user.email} already exists.`)
+        })
+    })
+
+    it('should return unauthorized if not logged in', async () => {
+      return http(app)
+        .post(uri)
+        .send(getFakerUser())
+        .expect(HttpStatus.UNAUTHORIZED)
+    })
+
+    it('should return user validation error', async () => {
+      const { tokens } = await createAdminUser(app)
+      const role = faker.lorem.words(5)
+
+      return http(app)
+        .post(uri)
+        .send({ role })
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          expect(body.message).toMatchObject([
+            'email must be a string',
+            'email should not be empty',
+            'role must be a valid enum value',
+          ])
+        })
+    })
+  })
+
+  describe('@PUT /users/:id', () => {
+    const uri = '/users/'
+
+    it('should return 200 if administrator normally update successfully', async () => {
+      const { tokens } = await createAdminUser(app)
+      const user = getFakerUser()
+
+      const userModel = await db.user.create({ data: user })
+
+      const updateData = {
+        firstname: faker.name.firstName(),
+        lastname: faker.name.lastName(),
+      }
+
+      return http(app)
+        .put(uri + userModel.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send(updateData)
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject(updateData)
+        })
+    })
+
+    it('should return 404 if administrator want to update the user is not found.', async () => {
+      const { tokens } = await createAdminUser(app)
+      const user = getFakerUser()
+
+      await db.user.create({ data: user })
+
+      const updateData = {
+        firstname: faker.name.firstName(),
+        lastname: faker.name.lastName(),
+      }
+
+      const id = faker.datatype.uuid()
+
+      return http(app)
+        .put(uri + id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send(updateData)
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          expect(body.message).toBe('The User to update is not found.')
+        })
+    })
+
+    it("should return 403 if the operator doesn't have the permission.", async () => {
+      const { tokens } = await createUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      const updateData = {
+        firstname: faker.name.firstName(),
+        lastname: faker.name.lastName(),
+      }
+
+      return http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send(updateData)
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+  })
+
+  describe('@PUT /users/password/:id', () => {
+    const uri = '/users/password/'
+
+    it('should return 200 if administrator update password successful', async () => {
+      const { tokens } = await createAdminUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      const password = faker.internet.password()
+
+      return http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({ password })
+        .expect(HttpStatus.OK)
+        .then(async ({ body }) => {
+          expect(body.data).toBeTruthy()
+          const checkUser = (await db.user.findUnique({
+            where: { id: user.id },
+          })) as User
+
+          expect(await hash.validate(password, checkUser.password)).toBeTruthy()
+        })
+    })
+
+    it("should return 403 if operator doesn't have the permission", async () => {
+      const { tokens } = await createUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      const password = faker.internet.password()
+
+      return http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({ password })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+
+    it('should return 400 because this method only update password of the user', async () => {
+      const { tokens } = await createAdminUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      const updateData = {
+        firstname: faker.name.firstName(),
+        lastname: faker.name.lastName(),
+      }
+
+      await http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send(updateData)
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          expect(body.message).toMatchObject([
+            'password must be a string',
+            'password should not be empty',
+          ])
+        })
+
+      const password = faker.internet.password()
+
+      return http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({ password, ...updateData })
+        .expect(HttpStatus.OK)
+        .then(async ({ body }) => {
+          expect(body.data).toBeTruthy()
+          const checkUser = await db.user.findUnique({ where: { id: user.id } })
+          expect(checkUser).not.toMatchObject(updateData)
+        })
+    })
+  })
+
+  describe('@PUT /users/role/:id', () => {
+    const uri = '/users/role/'
+
+    it('should return 200 and updated user', async () => {
+      const { tokens } = await createAdminUser(app)
+      const { user } = await createUser(app)
+
+      let changeRole: Role = Role.ADMIN
+
+      await http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({
+          role: changeRole,
+        })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            id: user.id,
+            role: changeRole,
+          })
+        })
+
+      changeRole = Role.USER
+
+      await http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({
+          role: changeRole,
+        })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            id: user.id,
+            role: changeRole,
+          })
+        })
+    })
+
+    it('should return 403 if operator does not have the permission', async () => {
+      const { tokens } = await createUser(app)
+      const { user } = await createUser(app)
+
+      await http(app)
+        .put(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({
+          role: Role.ADMIN,
+        })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+  })
+
+  describe('@DELETE /users/:id', () => {
+    const uri = '/users/'
+
+    it('should return 200 if administrator delete a user successfully', async () => {
+      const { tokens } = await createAdminUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      return http(app)
+        .delete(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            ...modelFactory.make(UserModel, user),
+          })
+        })
+    })
+
+    it("should return 403 if operator doesn't have the permission", async () => {
+      const { tokens } = await createUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      return http(app)
+        .delete(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+
+    it('should return 404 if administrator want to delete is not found', async () => {
+      const { tokens } = await createAdminUser(app)
+      const id = faker.datatype.uuid()
+
+      await db.user.create({ data: getFakerUser() })
+
+      return http(app)
+        .delete(uri + id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.NOT_FOUND)
+        .then(({ body }) => {
+          expect(body.message).toBe('The User to delete does not exist.')
+        })
+    })
+  })
+
+  describe('@GET /users/:id', () => {
+    const uri = '/users/'
+
+    it('should return 200 with user detail', async () => {
+      const { tokens } = await createAdminUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      return http(app)
+        .get(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            ...modelFactory.make(UserModel, user),
+          })
+        })
+    })
+
+    it('should return 403 if operator does not have the permission', async () => {
+      const { tokens } = await createUser(app)
+      const user = await db.user.create({ data: getFakerUser() })
+
+      return http(app)
+        .get(uri + user.id)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+  })
+
+  describe('@GET /users', () => {
+    const uri = '/users'
+
+    it('should return 200 with users array', async () => {
+      await resetDatabase()
+      const { user, tokens } = await createAdminUser(app)
+      const users = []
+
+      users.push(user)
+      for (const i of Array(10).fill('')) {
+        users.push(await db.user.create({ data: getFakerUser() }))
+      }
+
+      const checkUsers = map(users, (item) => {
+        return {
+          ...modelFactory.make(UserModel, item),
+        }
+      })
+
+      await http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject(checkUsers.reverse())
+        })
+    })
+
+    it('should return 403 if operator does not have the permission', async () => {
+      const { tokens } = await createUser(app)
+      const users = []
+
+      for (const i of Array(10).fill('')) {
+        users.push(await db.user.create({ data: getFakerUser() }))
+      }
+
+      return http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+  })
+
+  describe('@GET /users/search', () => {
+    const uri = '/users/search'
+
+    it('should return 200 with users array by search content', async () => {
+      const { user, tokens } = await createAdminUser(app)
+      const users = []
+
+      users.push(user)
+      for (const i of Array(10).fill('')) {
+        users.push(await db.user.create({ data: getFakerUser() }))
+      }
+
+      const checkUser = shuffle(users).pop() as User
+
+      await http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .query({
+          email: checkUser.email,
+        })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject([
+            {
+              ...modelFactory.make(UserModel, checkUser),
+            },
+          ])
+        })
+
+      await http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .query({
+          firstname: checkUser.firstname,
+        })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject([
+            {
+              ...modelFactory.make(UserModel, checkUser),
+            },
+          ])
+        })
+
+      await http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .query({
+          lastname: checkUser.lastname,
+        })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject([
+            {
+              ...modelFactory.make(UserModel, checkUser),
+            },
+          ])
+        })
+
+      await http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .query({
+          firstname: checkUser.firstname,
+          lastname: checkUser.lastname,
+        })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject([
+            {
+              ...modelFactory.make(UserModel, checkUser),
+            },
+          ])
+        })
+
+      await http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .query({
+          firstname: checkUser.firstname?.substring(0, 3),
+          lastname: checkUser.lastname?.substring(0, 3),
+        })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject([
+            {
+              ...modelFactory.make(UserModel, checkUser),
+            },
+          ])
+        })
+    })
+
+    it('should return 403 if operator does not have the permission.', async () => {
+      const { user, tokens } = await createUser(app)
+      const users = []
+
+      users.push(user)
+      for (const i of Array(10).fill('')) {
+        users.push(await db.user.create({ data: getFakerUser() }))
+      }
+
+      const checkUser = shuffle(users).pop() as User
+
+      await http(app)
+        .get(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .query({
+          email: checkUser.email,
+        })
+        .expect(HttpStatus.FORBIDDEN)
+        .then(({ body }) => {
+          expect(body.message).toBe("You don't have the permission")
+        })
+    })
+  })
+
+  describe('@PUT /users/update/me', () => {
+    const uri = '/users/update/me'
+
+    it('should return 200 with updated own user info', async () => {
+      const { user, tokens } = await createUser(app)
+      const firstname = faker.name.firstName()
+      const lastname = faker.name.lastName()
+      const email = faker.internet.email()
+
+      return http(app)
+        .put(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({ firstname, lastname, email })
+        .expect(HttpStatus.OK)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            id: user.id,
+            email: user.email,
+            firstname,
+            lastname,
+          })
+        })
+    })
+
+    it('should return unauthorized if not logged in', async () => {
+      await createUser(app)
+
+      return http(app)
+        .put(uri)
+        .send({
+          firstname: faker.name.firstName(),
+          lastname: faker.name.lastName(),
+        })
+        .expect(HttpStatus.UNAUTHORIZED)
+    })
+  })
+
+  describe('@PUT /users/me/password', () => {
+    const uri = '/users/me/password'
+
+    it('should return 200 with true', async () => {
+      const { user, tokens, password } = await createUser(app)
+      const newPassword = faker.internet.password()
+
+      return http(app)
+        .put(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({
+          oldPassword: password,
+          password: newPassword,
+        })
+        .expect(HttpStatus.OK)
+        .then(async ({ body }) => {
+          expect(body.data).toBeTruthy()
+
+          const checkUser = await db.user.findUnique({ where: { id: user.id } })
+
+          expect(
+            await hash.validate(newPassword, checkUser!.password)
+          ).toBeTruthy()
+        })
+    })
+
+    it('should return 400 if user submit fail oldPassword', async () => {
+      const { tokens } = await createUser(app)
+      const newPassword = faker.internet.password()
+
+      return http(app)
+        .put(uri)
+        .auth(tokens.accessToken, { type: 'bearer' })
+        .send({
+          password: newPassword,
+          oldPassword: faker.internet.password(),
+        })
+        .expect(HttpStatus.BAD_REQUEST)
+        .then(({ body }) => {
+          expect(body.message).toBe('password is incorrect')
+        })
+    })
+
+    it('should return unauthorized if not logged in', async () => {
+      const { password } = await createUser(app)
+
+      return http(app)
+        .put(uri)
+        .send({
+          password: faker.internet.password(),
+          oldPassword: password,
+        })
+        .expect(HttpStatus.UNAUTHORIZED)
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "target": "es2017",
+    "target": "es2019",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
新增UsersController:实现后台的CRUD，客户端的修改密码与修改firstname & lastname；新增PrismaErrorCode文件：对应known exception code；新增constants：进行系统固定配置的调用项；新增Roles装饰器：对用户的角色权限进行控制；新增Serializer装饰器：针对返回的数据统一进行序列化；